### PR TITLE
Restrict project PHP version to 5.5.33 & update packages.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,23 @@
 {
-  "name": "hub-it/club",
-  "description": "Web application for the DEREE - Bus Tracking system.",
-  "type": "project",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Antony Kalogeropoulos",
-      "email": "anthonykalogeropoulos@gmail.com"
-    }
-  ],
-  "require": {
-    "corneltek/pux": "^1.5",
-    "league/plates": "^3.1",
-    "vlucas/phpdotenv": "^2.2"
-  },
-  "autoload": {
-    "psr-4": {
-      "CodeBurrow\\": "app/"
-    }
-  }
+   "name": "hub-it/club",
+   "description": "Web application for the DEREE - Bus Tracking system.",
+   "type": "project",
+   "license": "MIT",
+   "authors": [
+	  {
+		 "name": "Antony Kalogeropoulos",
+		 "email": "anthonykalogeropoulos@gmail.com"
+	  }
+   ],
+   "require": {
+	  "php": "5.5.33",
+	  "corneltek/pux": "^1.5",
+	  "league/plates": "^3.1",
+	  "vlucas/phpdotenv": "^2.2"
+   },
+   "autoload": {
+	  "psr-4": {
+		 "CodeBurrow\\": "app/"
+	  }
+   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cfb25a22fbb05900db6377e5911c1761",
+    "hash": "1212998926b45fad4bf6e6ac91cf052d",
+    "content-hash": "653951428fa8be2eceeb279a29aefad5",
     "packages": [
         {
             "name": "corneltek/class-template",
@@ -715,6 +716,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "5.5.33"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
- One cool thing with composer is that you can restrict the PHP version. For example if we try to use a different a PHP version on our development machine (I use PHP 7.0), then it restricts us from install/update packages.
- Another example, the latest PHPUnit requires at least PHP 5.6. Using this restriction we not fall into the trap of using functions/libraries not supported. 
- Don't forget to run `composer install` to update your local packages.

If you wish to add multiple version to your local machine, please check https://github.com/phpbrew/phpbrew
